### PR TITLE
feat: configs semantic release to publish to npm

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,7 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
+    "@semantic-release/npm",
     "@semantic-release/github",
     ["@semantic-release/git", {
       "assets": ["package.json", "CHANGELOG.md"],

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@commitlint/config-conventional": "^17.8.1",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/npm": "^12.0.1",
 		"@types/node": "^22.13.10",
 		"@typescript-eslint/eslint-plugin": "^6.0.0",
 		"@typescript-eslint/parser": "^6.0.0",


### PR DESCRIPTION
Configures semantic release to push a package to npm upon a release. 

With this change releases will be auto pushed to npm 🚄 

A secret has been added to the repo named NPM_TOKEN from the https://www.npmjs.com/settings/smartsheet/ org 


Example dry run 
```
GH_TOKEN={REDACTED} NPM_TOKEN={REDACTED} npx semantic-release --dry-run --no-ci --exte
nds=./.releaserc.dryrun.json
[6:50:33 PM] [semantic-release] › ℹ  Running semantic-release version 22.0.12
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/changelog"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/git"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/git"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/github"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[6:50:34 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[6:50:37 PM] [semantic-release] › ⚠  Run automated release from branch main on repository git+https://github.com/smartsheet-platform/smar-mcp.git in dry-run mode
[6:50:37 PM] [semantic-release] › ✔  Allowed to push to the Git repository
[6:50:37 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/changelog"
[6:50:37 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/changelog"
[6:50:37 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
[6:50:37 PM] [semantic-release] [@semantic-release/npm] › ℹ  Verify authentication for registry https://registry.npmjs.org/
[6:50:37 PM] [semantic-release] [@semantic-release/npm] › ℹ  Wrote NPM_TOKEN to /private/var/folders/c3/52fdgdxx6m38t044t2pszq7w0000gp/T/867fb49f95be047152e621d72000fb81/.npmrc
imran-smar
[6:50:38 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
[6:50:38 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/github"
[6:50:38 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication
[6:50:38 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/github"
[6:50:38 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/git"
[6:50:38 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/git"
[6:50:38 PM] [semantic-release] › ℹ  Found git tag v1.2.0 associated with version 1.2.0 on branch main
[6:50:38 PM] [semantic-release] › ℹ  Found 38 commits since last release
[6:50:38 PM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Merge pull request #21 from smartsheet-platform/roo-code-marketplace

changes to create and publish node package
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: bump version from 0.0.27 to 1.0.0 for initial stable release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: bump package version from 0.0.25 to 0.0.27
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add sheet search by URL and row retrieval endpoints with pagination support
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add what_am_i_assigned_to tool for finding user's assigned tasks in a sheet
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: move discussion methods from sheet API to dedicated discussion API with pagination support
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: remove create_sheet_discussion tool and bump version to 0.0.18
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: replace winston logger with console logging
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add discussion management tools and API endpoints for sheets and rows
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add get_sheet_by_url tool and support for directIdToken sheet retrieval
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: implement platform-specific log rotation with winston-daily-rotate-file
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: update package.json with metadata, scripts, and publishing config
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: bump package version from 0.0.7 to 0.0.8
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: replace console logging with structured winston logger
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add list users API endpoint and tool command
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: bump package version to 0.0.6
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: bump version to 0.0.5
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: correct API endpoint path from /search/sheet to /search/sheets
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add searchSheet API endpoint and tool for searching within specific sheets
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Update src/tools/smartsheet-workspace-tools.ts

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Merge pull request #25 from smartsheet-platform/server-tool-search

organize tools into separate modules and add search tools
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add search endpoints for folders, workspaces, reports and dashboards
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: organize tools into separate modules and add search functionality
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: change error log to info level for sheet copy result
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: configure Jest test framework and update build scripts
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Apply suggestions from code review

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: add dotenv dependency and ignore .roo directory
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: feat: add dotenv configuration and .roo directory to gitignore
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is minor
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: refactor: reorganize Smartsheet API into modular TypeScript classes
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: fix indentation in package.json build script
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: update publish script to build before publishing
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: chore: simplify build script and add npm publish command
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: build: changes to create and publis node package
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Merge pull request #17 from smartsheet-platform/sean-sekora/additional-tools

Adds new tools and type definitions for creating and retrieving workspaces and folders via the Smartsheet API.

- Introduces SmartsheetWorkspace and SmartsheetFolder interfaces.
- Adds new API methods in SmartsheetDirectAPI for workspace and folder operations.
- Registers new server tools in src/index.ts to expose these functionalities.
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Corrected wording
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Adds tools for creating and retrieving workspaces and folders
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: Merge pull request #16 from llarue-smartsheet/endpoint_config

add endpoint configuration to .env
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: add endpoint configuration to .env
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
[6:50:38 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 38 commits complete: minor release
[6:50:38 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[6:50:38 PM] [semantic-release] › ℹ  The next release version is 1.3.0
[6:50:38 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:50:38 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:50:38 PM] [semantic-release] › ⚠  Skip step "prepare" of plugin "@semantic-release/changelog" in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip step "prepare" of plugin "@semantic-release/npm" in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip step "prepare" of plugin "@semantic-release/git" in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip v1.3.0 tag creation in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/npm" in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/github" in dry-run mode
[6:50:39 PM] [semantic-release] › ⚠  Skip step "success" of plugin "@semantic-release/github" in dry-run mode
[6:50:39 PM] [semantic-release] › ✔  Published release 1.3.0 on default channel
[6:50:39 PM] [semantic-release] › ℹ  Release note for version 1.3.0:
# 1.3.0 (2025-06-09)

### Bug Fixes

    * change error log to info level for sheet copy result (41e4961)
    * correct API endpoint path from /search/sheet to /search/sheets (2ff5898)
    * update publish script to build before publishing (5aec64d)

### Features

    * add discussion management tools and API endpoints for sheets and rows (728e4a5)
    * add dotenv configuration and .roo directory to gitignore (aba689d)
    * add get_sheet_by_url tool and support for directIdToken sheet retrieval (6e3b2a3)
    * add list users API endpoint and tool command (25e8dc5)
    * add search endpoints for folders, workspaces, reports and dashboards (79b71fc)
    * add searchSheet API endpoint and tool for searching within specific sheets (bccd85f)
    * add sheet search by URL and row retrieval endpoints with pagination support (2308f21)
    * add what_am_i_assigned_to tool for finding user's assigned tasks in a sheet (086d794)
    * implement platform-specific log rotation with winston-daily-rotate-file (895da94)
    * replace console logging with structured winston logger (cad6cff)
```