### PR TITLE
Add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear and concise description of what the bug is -->
+
+## Steps To Reproduce
+<!-- Steps to reproduce the behavior -->
+1. 
+2. 
+3. 
+4. 
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+<!-- Please complete the following information -->
+ - OS: [e.g. macOS, Windows, Linux]
+ - Node.js version: [e.g. 16.14.0]
+ - npm/yarn version: [e.g. 8.3.1]
+ - Project version: [e.g. 1.0.0]
+
+## Additional Context
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/smartsheet-platform/smar-mcp/discussions
+    about: Please ask questions here if you need help with using the project
+  - name: Documentation
+    url: https://github.com/smartsheet-platform/smar-mcp/wiki
+    about: Check our documentation for usage information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+<!-- A clear and concise description of what problem this feature would solve. Ex. I'm always frustrated when [...] -->
+
+## Proposed Solution
+<!-- A clear and concise description of what you want to happen -->
+
+## Alternative Solutions
+<!-- A clear and concise description of any alternative solutions or features you've considered -->
+
+## Additional Context
+<!-- Add any other context or screenshots about the feature request here -->

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,37 @@
+# Pull Request
+
+## Description
+<!-- Provide a brief summary of the changes in this pull request -->
+
+## Related Issue
+<!-- Please link to the issue here, e.g. "Fixes #123" -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!-- Please describe how you tested your changes -->
+- [ ] Unit Tests
+- [ ] Integration Tests
+- [ ] Manual Testing
+
+## Screenshots (if appropriate)
+<!-- Add screenshots of the feature or fix -->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+
+## Checklist
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] My code follows the code style of this project
+- [ ] My change requires a change to the documentation
+- [ ] I have updated the documentation accordingly
+- [ ] I have added tests to cover my changes
+- [ ] All new and existing tests passed
+- [ ] I have checked that my changes do not introduce any new warnings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# Pull Request
+
+## Description
+<!-- Provide a brief summary of the changes in this pull request -->
+
+## Related Issue
+<!-- Please link to the issue here, e.g. "Fixes #123" -->
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Other (please describe):
+
+## How Has This Been Tested?
+<!-- Please describe how you tested your changes -->
+
+## Checklist
+- [ ] My code follows the code style of this project
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the documentation accordingly
+- [ ] My changes generate no new warnings or errors

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ coverage/
 .clinerules*
 memory-bank
 projectBrief.md
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file contains configuration and instructions for Claude to help with this repository.
+
+## Repository Overview
+This repository contains a Smartsheet Model Context Protocol (MCP) server that provides tools for interacting with the Smartsheet API.
+
+## GitHub Commands
+
+### Creating Issues
+```bash
+# Basic issue creation
+gh issue create --title "Issue title" --body "Issue description"
+
+# With labels and assignees
+gh issue create --title "Issue title" --body "Issue description" --label "bug,enhancement" --assignee "username"
+```
+
+### Creating Pull Requests
+```bash
+# Basic PR creation
+gh pr create --title "PR title" --body "PR description"
+
+# With reviewers and labels
+gh pr create --title "PR title" --body "PR description" --reviewer "username" --label "enhancement"
+
+# Using a HEREDOC for better formatting of the PR body
+gh pr create --title "PR title" --body "$(cat <<'EOF'
+## Summary
+Summary text here
+
+## Test plan
+- Testing details
+EOF
+)"
+```
+
+### Updating Pull Requests
+```bash
+# Update title and body
+gh pr edit [PR number] --title "New title" --body "New description"
+
+# Add/remove labels
+gh pr edit [PR number] --add-label "enhancement" --remove-label "bug"
+
+# Add/remove reviewers
+gh pr edit [PR number] --add-reviewer "username" --remove-reviewer "another-user"
+```
+
+### Fetching PR Comments
+```bash
+# View PR with comments
+gh pr view [PR number] --comments
+
+# Get comments in JSON format
+gh pr view [PR number] --comments --json comments
+```
+
+### Adding Comments to PRs
+```bash
+# Add a comment to a PR
+gh pr comment [PR number] --body "This looks good!"
+```
+
+## Repository Structure
+```
+.github/
+  ├── ISSUE_TEMPLATE/
+  │   ├── bug_report.md      # Template for bug reports
+  │   ├── feature_request.md # Template for feature requests
+  │   └── config.yml         # Issue template configuration
+  └── PULL_REQUEST_TEMPLATE/
+      └── default.md         # Default PR template
+```
+
+## Development Commands
+
+Add common development commands here that should be run regularly.
+
+## Code Conventions
+
+Add code conventions specific to this repository here.


### PR DESCRIPTION
## Summary
- Add standardized PR template for consistent code submissions
- Add issue templates for bug reports and feature requests
- Add configuration for GitHub issue templates
- Add CLAUDE.md with documentation about repository structure and GitHub CLI commands
- Update .gitignore to exclude CLAUDE.local.md

## Test plan
- Verify PR template appears when creating new PRs
- Verify issue templates appear when creating new issues
- Verify CLAUDE.md contains accurate repository information and commands
- Verify CLAUDE.local.md is excluded from git tracking

🤖 Generated with [Claude Code](https://claude.ai/code)